### PR TITLE
feat(auth): implement login and signup UI with basic styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import { Nav } from "src/components/Nav";
 import { RecipePage } from "src/pages/RecipePage";
+import { HomePage } from "src/pages/HomePage";
 import { AddPost } from "/src/pages/Post/AddPost";
+import { Login } from "/src/pages/Auth/Login";
+import { SignUp } from "/src/pages/Auth/SignUp";
 
 import {
   BrowserRouter as Router,
@@ -15,8 +18,11 @@ export function App() {
         <Router>
           <Nav />
           <Routes>
-            <Route path="/" element={<RecipePage />} />
-            <Route path="/addpost" element={<AddPost />} />
+            <Route path="/" element={<HomePage />} />
+            <Route path="/recipe-page" element={<RecipePage />} />
+            <Route path="/add-post" element={<AddPost />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<SignUp />} />
           </Routes>
         </Router>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,9 @@
 }
 
 @layer utilities {
+  .archBackground {
+    @apply rounded-tl-[150px] rounded-tr-[150px] bg-blue800 bg-[url('/src/assets/images/img-noise.png')];
+  }
   .checkboxIconStyle {
     @apply h-[30px] w-[30px] cursor-pointer border-[3px];
   }
@@ -42,5 +45,14 @@
   }
   .darkInputField {
     @apply bg-[#1E1E3F] text-[#FFD28F] placeholder:text-[#FFD28F]/50 focus:border-[#FF6F00];
+  }
+  .loginSingupInput {
+    @apply rounded-full border border-[#917262] bg-transparent p-6 outline-none transition-colors duration-1000;
+  }
+  .loginSingupInputField {
+    @apply tracking-widest text-[#FFD28F] placeholder:text-[#FFD28F]/50 focus:border-[#FFEF88];
+  }
+  .loginSingupBtn {
+    @apply my-4 rounded-full bg-yellow400 p-4 transition-transform duration-200 hover:bg-orange active:scale-95;
   }
 }

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -1,0 +1,7 @@
+export function Login() {
+  return (
+    <div>
+      
+    </div>
+  )
+}

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -1,7 +1,78 @@
+import { GoEye } from "react-icons/go";
+import { RxEyeClosed } from "react-icons/rx";
+import { Link } from "react-router-dom";
+import { useRef, useState } from "react";
+
 export function Login() {
+  const emailRef = useRef();
+  const passwordRef = useRef();
+  const [passwordShow, setPasswordShow] = useState(false);
+  const [hasPassword, setHasPassword] = useState(false);
+  const handlePasswordChange = (e) => {
+    const value = e.target.value;
+    setHasPassword(value.length > 0);
+  };
+
   return (
-    <div>
-      
-    </div>
-  )
+    <main className="archBackground flex h-screen w-full justify-center">
+      <div className="mt-40 flex w-full flex-col gap-y-6 p-6 500:max-w-[28rem]">
+        <h1 className="mb-6 w-full text-center font-youngSerif text-6xl text-orange">
+          Sign In
+        </h1>
+
+        <form className="flex w-full flex-col gap-y-5">
+          <div className="flex flex-col justify-start gap-y-2">
+            <label
+              htmlFor="inputEmail"
+              className="font-semibold text-orange"
+            >
+              Email Address
+            </label>
+            <input
+              type="email"
+              ref={emailRef}
+              id="inputEmail"
+              className="loginSingupInput loginSingupInputField"
+              placeholder="Email Address"
+              required
+              name="email"
+            />
+          </div>
+          <div className="relative flex flex-col gap-y-2">
+            <label
+              htmlFor="inputPassword"
+              className="font-semibold text-orange"
+            >
+              Password
+            </label>
+            <input
+              name="password"
+              type={passwordShow ? "text" : "password"}
+              ref={passwordRef}
+              id="inputPassword"
+              className="loginSingupInput loginSingupInputField tracking-wider"
+              placeholder="Password"
+              required
+              onChange={handlePasswordChange}
+            />
+            {hasPassword && (
+              <span
+                className="text-yellow300 absolute bottom-7 right-6 cursor-pointer"
+                onClick={() => setPasswordShow(!passwordShow)}
+              >
+                {passwordShow ? <GoEye /> : <RxEyeClosed />}
+              </span>
+            )}
+          </div>
+
+          <button type="submit" className="loginSingupBtn">
+            Continue your recipe collection 😋
+          </button>
+          <Link className="text-beige300 underline" to="/signup">
+            Sign up
+          </Link>
+        </form>
+      </div>
+    </main>
+  );
 }

--- a/src/pages/Auth/SignUp.jsx
+++ b/src/pages/Auth/SignUp.jsx
@@ -1,0 +1,7 @@
+export function SignUp() {
+  return (
+    <div>
+      
+    </div>
+  )
+}

--- a/src/pages/Auth/SignUp.jsx
+++ b/src/pages/Auth/SignUp.jsx
@@ -1,7 +1,95 @@
+import { GoEye } from "react-icons/go";
+import { RxEyeClosed } from "react-icons/rx";
+import { Link } from "react-router-dom";
+import { useRef, useState } from "react";
+
 export function SignUp() {
+  const emailRef = useRef();
+  const passwordRef = useRef();
+  const [passwordShow, setPasswordShow] = useState(false);
+  const [hasPassword, setHasPassword] = useState(false);
+  const handlePasswordChange = (e) => {
+    const value = e.target.value;
+    setHasPassword(value.length > 0);
+  };
+
   return (
-    <div>
-      
-    </div>
-  )
+    <main className="archBackground flex h-screen w-full justify-center">
+      <div className="mt-40 flex w-full flex-col gap-y-6 p-6 500:max-w-[28rem]">
+        <h1 className="mb-6 w-full text-center font-youngSerif text-6xl text-orange">
+          New User
+        </h1>
+        <form className="flex w-full flex-col gap-y-5">
+          <div className="flex flex-col justify-start gap-y-2">
+            <label
+              htmlFor="inputEmail"
+              className="font-semibold text-orange"
+            >
+              Name
+            </label>
+            <input
+              type="text"
+              ref={emailRef}
+              id="inputName"
+              className="loginSingupInput loginSingupInputField"
+              placeholder="Name"
+              required
+              name="name"
+            />
+          </div>
+
+          <div className="flex flex-col justify-start gap-y-2">
+            <label
+              htmlFor="inputEmail"
+              className="font-semibold text-orange"
+            >
+              Email Address
+            </label>
+            <input
+              type="email"
+              ref={emailRef}
+              id="inputEmail"
+              className="loginSingupInput loginSingupInputField"
+              placeholder="Email Address"
+              required
+              name="email"
+            />
+          </div>
+
+          <div className="relative flex flex-col gap-y-2">
+            <label
+              htmlFor="inputPassword"
+              className="font-semibold text-orange"
+            >
+              Password
+            </label>
+            <input
+              name="password"
+              type={passwordShow ? "text" : "password"}
+              ref={passwordRef}
+              id="inputPassword"
+              className="loginSingupInput loginSingupInputField tracking-wider"
+              placeholder="Password"
+              required
+              onChange={handlePasswordChange}
+            />
+            {hasPassword && (
+              <span
+                className="text-yellow300 absolute bottom-7 right-6 cursor-pointer"
+                onClick={() => setPasswordShow(!passwordShow)}
+              >
+                {passwordShow ? <GoEye /> : <RxEyeClosed />}
+              </span>
+            )}
+          </div>
+          <button type="submit" className="loginSingupBtn">
+            Start your recipe collection 📖
+          </button>
+          <Link className="text-beige300 underline" to="/login">
+            Log In
+          </Link>
+        </form>
+      </div>
+    </main>
+  );
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,0 +1,7 @@
+export function HomePage() {
+  return (
+    <div>
+      
+    </div>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
         beige500: "#917262",
         yellow: "#FFFCC9",
         yellow200:"#FFEF88",
+        yellow300:"#FFD28F",
         yellow400:"#FFC444 ",
         orange: "#FF841F",
         orange100: "#FFC89A",


### PR DESCRIPTION
This PR implements the initial login and signup pages with:

- Email and password input fields using useRef
- Password visibility toggle with icon
- Custom styles for background, inputs, and buttons
- Tailwind config update for yellow color shades

Formik integration will be added in a follow-up PR.
![authPages](https://github.com/user-attachments/assets/f585f61b-8550-4fdd-8542-b64b876a5e25)
