### PR TITLE
fix(auth): correct onAuthStateChange parameters to update user state

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -23,7 +23,7 @@ export function AuthProvider({ children }) {
     setLoading(false);
 
     const { data: listener } = supabase.auth.onAuthStateChange(
-      async ( session) => {
+      (event, session) => {
         setUser(session?.user ?? null);
         setLoading(false);
       },
@@ -42,8 +42,7 @@ export function AuthProvider({ children }) {
       });
       if (error) throw error;
       if (user) {
-        const {  error: updateError } = 
-          await supabase.auth.update({
+        const { error: updateError } = await supabase.auth.update({
           data: { name },
         });
         if (updateError) throw updateError;


### PR DESCRIPTION
### 💡 Summary
This PR fixes a bug where the user state was not being updated correctly
after login or logout due to incorrect usage of `onAuthStateChange` from Supabase v1.

### ✅ Changes Made
- Corrected `onAuthStateChange` callback to use `(event, session)` format
- Minor code cleanup on `updateError` assignment for Supabase `auth.update`

### 🧪 How to Test
1. Log in using the login form
2. Ensure that the navigation menu updates from "Log in" to "Sign out"
3. Log out and check if state returns to "Log in"

### 📌 Context
- Supabase v1 `onAuthStateChange` provides two parameters: `(event, session)`
- The previous implementation mistakenly treated `session` as the only argument

