### PR TITLE
Refactor homepage layout and unify add-recipe route naming

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ export function App() {
               <Routes>
                 <Route path="/" element={<HomePage />} />
                 <Route path="/recipe-page/:id" element={<RecipePage />} />
-                <Route path="/add-post" element={<AddPost />} />
+                <Route path="/add-recipe" element={<AddPost />} />
                 <Route path="/edit/:id" element={<AddPost />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/signup" element={<SignUp />} />

--- a/src/components/HomePageCard.jsx
+++ b/src/components/HomePageCard.jsx
@@ -2,7 +2,7 @@ import { RecipeImage } from "src/components/RecipeImage";
 
 export const HomePageCard = ({ item }) => {
   return (
-    <div className="flex w-[350px] flex-col items-center gap-3 rounded-2xl bg-white300 py-4 text-white outline md:w-[300px] lg:w-[290px]">
+    <div className="group flex w-[350px] flex-col items-center gap-3 rounded-2xl bg-white300 py-4 text-white ring-2 ring-white ring-offset-2 md:w-[300px] lg:w-[290px]">
       <div className="h-[250px] w-[300px] overflow-hidden rounded-3xl border-[3px] border-orange600 hover:border-orange md:h-[280px] md:w-[280px]">
         <RecipeImage className="homePageFoodCardImg" src={item?.image} alt={item?.recipe_name} />
       </div>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -8,7 +8,7 @@ import { NavItem } from "src/components/NavItem";
 
 const ROUTES = [
   { id: "", label: "Home" },
-  { id: "add-post", label: "Add Recipe" },
+  { id: "add-recipe", label: "Add Recipe" },
   { id: "cart", label: "Cart" },
 ];
 

--- a/src/components/homePage/HomePageCard.jsx
+++ b/src/components/homePage/HomePageCard.jsx
@@ -1,6 +1,7 @@
 import { RecipeImage } from "src/components/RecipeImage";
 
 export const HomePageCard = ({ item }) => {
+
   return (
     <div className="group flex w-[350px] flex-col items-center gap-3 rounded-2xl bg-white300 py-4 text-white ring-2 ring-white ring-offset-2 md:w-[300px] lg:w-[290px]">
       <div className="h-[250px] w-[300px] overflow-hidden rounded-3xl border-[3px] border-orange600 hover:border-orange md:h-[280px] md:w-[280px]">

--- a/src/index.css
+++ b/src/index.css
@@ -120,7 +120,7 @@
     box-shadow: 0px 0px 20px 16px rgba(249, 238, 205, 0.15);
   }
   .homePageFoodCardImg {
-    @apply h-full w-full cursor-pointer rounded-xl object-cover object-center transition-transform duration-200 hover:scale-[1.15];
+    @apply h-full w-full cursor-pointer rounded-xl object-cover object-center transition-transform duration-200 group-hover:scale-[1.15];
   }
   .actionBtn {
     @apply border border-orange bg-transparent px-4 py-2 text-red transition-colors duration-1000;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -58,7 +58,7 @@ export function HomePage() {
       <div>
         <IconLogo className="h-40 w-40" />
       </div>
-      <div className="flex w-full flex-col items-center gap-y-6 px-6 py-12 500:max-w-[28rem] md:max-w-[700px] 990:max-w-[1400px]">
+      <div className="flex min-h-screen w-full flex-col items-center gap-y-6 px-6 py-12 500:max-w-[28rem] md:max-w-[700px] 990:max-w-[1400px]">
         {displayName && (
           <h3 className="w-full text-center text-lg font-medium text-white300">
             Welcome back, {displayName} 👩‍🍳

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import IconLogo from "src/assets/icons/amuamu-logo.svg?react";
 import { useState, useEffect } from "react";
 import { useAuth } from "src/context/AuthContext";
 import { supabase } from "src/supabaseClient";
-import { HomePageCard } from "src/components/HomePageCard";
+import { HomePageCard } from "src/components/homePage/HomePageCard";
 import { Link } from "react-router-dom";
 import Fuse from "fuse.js";
 

--- a/src/pages/RecipePage.jsx
+++ b/src/pages/RecipePage.jsx
@@ -110,9 +110,9 @@ export function RecipePage() {
               alt={data?.recipe_name}
             />
           </div>
-          <SharedByUserLabel loginUserId={user.id} recipeUserId={data.user_id} />
+          <SharedByUserLabel loginUserId={user?.id} recipeUserId={data.user_id} />
           {/* user edit delete */}
-          {user.id === data.user_id && (
+          {user?.id === data.user_id && (
             <div className="flex w-full items-center justify-center gap-10 text-blue100">
               <button
                 className="actionBtn:hover actionBtn rounded-xl"


### PR DESCRIPTION
## Summary
This PR includes several improvements to the homepage layout and consistent naming for the add-recipe route.

## What's Changed
- **Refactored** `HomePageCard` : replaced the outline with a ring style and applied `group-hover` to scale the image only when hovering over the entire card
- **Moved** `HomePageCard.jsx` to `components/homePage/` for better folder organization
- **Applied** `min-h-screen` on `HomePage` to maintain layout consistency when there's no data
- **Renamed** route and nav ID from `/add-post` to `/add-recipe` for clarity

## Before
- `HomePageCard` was directly under `components/`, and had no `ring` or to scale image only when hovering just the image.
- The `HomePage` layout height was inconsistent when no content was present
- Inconsistent route naming: used `/add-post` in routes, even though the actual functionality is "Add Recipe"

## After
- `HomePageCard` now uses a `ring-white` style instead of `outline` to ensure rounded corners render correctly across browsers (e.g., In Safari, using outline caused the border-radius to be ignored, resulting in sharp corners.)
- Image scaling now only triggers when hovering the entire card (`group-hover`), offering a more intuitive user experience
- Homepage layout remains stable with `min-h-screen` even when no content is loaded
- Route and navigation path for adding recipes is now consistently `/add-recipe`

## How to Test
1. Visit `/` and verify homepage layout and card hover effects
2. Confirm that navigation to "Add Recipe" goes to `/add-recipe` and not `/add-post`
3. Check that layout no longer jumps when the homepage has no recipes
4. Review file structure: `HomePageCard.jsx` should be under `components/homePage/`

## Related Branch / Issues
- Branch: `refactor/homePage-ui`

## Images
 `HomePage` layout height varied if no content was present
![layout-no-min-h png](https://github.com/user-attachments/assets/4d6ad286-2e0c-4b02-942c-195250c47cf0)

Homepage layout remains stable with min-h-screen 
![layout-with-min-h png](https://github.com/user-attachments/assets/d8f7b793-ab3f-4896-adf1-ff278921b095)

Safari ignored border-radius with outline
![outline-safari-no-bdrd](https://github.com/user-attachments/assets/76a658a2-78df-46da-944c-35f090791700)
