### PR TITLE
feat(recipe): hide carousel when only one image and adjust spacing

### DIFF
--- a/src/components/recipe/RecipeImageCarousel.jsx
+++ b/src/components/recipe/RecipeImageCarousel.jsx
@@ -28,7 +28,7 @@ const settings = {
 export function RecipeImageCarousel({ imageArray = [] }) {
   return (
     Array.isArray(imageArray) &&
-    imageArray.length > 0 && (
+    imageArray.length > 1 && (
       <div className="mt-4 h-full w-full rounded-xl border border-yellow/20 p-4">
         <Slider {...settings} className="h-full w-full">
           {imageArray.map((src, index) => (
@@ -36,7 +36,7 @@ export function RecipeImageCarousel({ imageArray = [] }) {
               key={index}
               src={src}
               alt={`Preview ${index}`}
-              className="h-[150px] w-[150px] rounded-md object-cover"
+              className="h-[150px] w-[150px] rounded-md object-cover px-2"
             />
           ))}
         </Slider>


### PR DESCRIPTION
### What’s Changed

✅ Hide carousel when only one image
When a recipe includes only one image, the image carousel (thumbnail strip) is no longer rendered to avoid unnecessary UI elements.

✅ Add spacing between preview thumbnails
Used `px-2` horizontal padding to each image preview to visually separate thumbnails and improve layout clarity.

### Visual Comparison

| Hide carousel when only one image | Add spacing between preview thumbnails |
|-----------------------------------|----------------------------------------|
|![hide-carousel](https://github.com/user-attachments/assets/4abb7617-4f5b-4f8d-8934-2b2eed276f29)    | ![carousel-spacing](https://github.com/user-attachments/assets/b9ce0d59-9d60-451d-aa18-000339f54046)  |



