### PR TITLE
refactor(homePageCard): display first image from image array

### DIFF
--- a/src/components/homePage/HomePageCard.jsx
+++ b/src/components/homePage/HomePageCard.jsx
@@ -35,7 +35,7 @@ export const HomePageCard = ({ item }) => {
   return (
     <div className="group/card flex w-[350px] flex-col items-center gap-3 rounded-2xl bg-white300 py-4 text-white ring-2 ring-white ring-offset-2 md:w-[300px] lg:w-[290px]">
       <div className="h-[250px] w-[300px] overflow-hidden rounded-3xl border-[3px] border-orange600 group-hover/card:border-orange md:h-[280px] md:w-[280px]">
-        <RecipeImage className="homePageFoodCardImg" src={item?.image} alt={item?.recipe_name} />
+        <RecipeImage className="homePageFoodCardImg" src={item?.image[0]} alt={item?.recipe_name} />
       </div>
       <h3 className="w-full max-w-[280px] truncate text-center text-2xl font-semibold text-blue800">
         {item.recipe_name}


### PR DESCRIPTION
This PR updates the `HomePageCard` component to support recipes with multiple images.

Previously, `item.image` was assumed to be a single string (image URL).
Now that `item.image` is an array, we display the **first image** using `item.image[0]`.

If `item.image[0]` is missing or undefined, the fallback logic will still show the default image.

## Before & After
- **Before**: `src={item?.image}` → default image shown due to image URL mismatch (see left screenshot).
- **After**: `src={item?.image[0]}` → actual recipe image displayed correctly (see right screenshot).
![image](https://github.com/user-attachments/assets/8881580e-67e8-47a6-afb3-ba59acb6cd2d)

## Impact
- This change ensures visual consistency on the homepage.